### PR TITLE
Jl/fix set compression order

### DIFF
--- a/core/src/main/scala/io/prediction/core/SelfCleaningDataSource.scala
+++ b/core/src/main/scala/io/prediction/core/SelfCleaningDataSource.scala
@@ -218,18 +218,18 @@ trait SelfCleaningDataSource {
   @DeveloperApi
   def cleanPEvents(sc: SparkContext): RDD[Event] = {
    val pEvents = PEventStore.find(appName)(sc).sortBy(_.eventTime, false)
-   val pRecentEvents = getCleanedPEvents(pEvents)
 
-   eventWindow match {
+   val rdd = eventWindow match {
       case Some(ew) =>
         var updated =
-          if (ew.compressProperties) compressPProperties(sc, pRecentEvents) else pRecentEvents
+          if (ew.compressProperties) compressPProperties(sc, pEvents) else pEvents
 
-        val deduped = if (ew.removeDuplicates) removePDuplicates(sc, updated) else updated
+        val deduped = if (ew.removeDuplicates) removePDuplicates(sc,updated) else updated
         deduped
       case None =>
-        pRecentEvents
+        pEvents
     }
+  getCleanedPEvents(rdd)
   }
 
   /** :: DeveloperApi ::
@@ -263,17 +263,17 @@ trait SelfCleaningDataSource {
   @DeveloperApi
   def cleanLEvents(): Iterable[Event] = {
     val lEvents = LEventStore.find(appName).toList.sortBy(_.eventTime).reverse
-    val lRecentEvents = getCleanedLEvents(lEvents)
 
-    eventWindow match {
+    val events = eventWindow match {
       case Some(ew) =>
         var updated =
-          if (ew.compressProperties) compressLProperties(lRecentEvents) else lRecentEvents
+          if (ew.compressProperties) compressLProperties(lEvents) else lEvents
           val deduped = if (ew.removeDuplicates) removeLDuplicates(updated) else updated
         deduped
       case None =>
-        lRecentEvents
+        lEvents
     }
+    getCleanedLEvents(events)
   }
 
 

--- a/core/src/main/scala/io/prediction/core/SelfCleaningDataSource.scala
+++ b/core/src/main/scala/io/prediction/core/SelfCleaningDataSource.scala
@@ -293,13 +293,14 @@ trait SelfCleaningDataSource {
               e1.properties.fields
                 .filterKeys(f => !e2.properties.fields.contains(f))
           }
-          e1.copy(properties = DataMap(props))
+          e1.copy(properties = DataMap(props), eventTime = e2.eventTime)
         }
 
       case None =>
         events.reduce { (e1, e2) =>
           e1.copy(properties =
-            DataMap(e1.properties.fields ++ e2.properties.fields)
+            DataMap(e1.properties.fields ++ e2.properties.fields),
+            eventTime = e2.eventTime
           )
         }
     }

--- a/core/src/main/scala/io/prediction/core/SelfCleaningDataSource.scala
+++ b/core/src/main/scala/io/prediction/core/SelfCleaningDataSource.scala
@@ -218,18 +218,18 @@ trait SelfCleaningDataSource {
   @DeveloperApi
   def cleanPEvents(sc: SparkContext): RDD[Event] = {
    val pEvents = PEventStore.find(appName)(sc).sortBy(_.eventTime, false)
+   val pRecentEvents = getCleanedPEvents(pEvents)
 
-   val rdd = eventWindow match {
+   eventWindow match {
       case Some(ew) =>
         var updated =
-          if (ew.compressProperties) compressPProperties(sc, pEvents) else pEvents
+          if (ew.compressProperties) compressPProperties(sc, pRecentEvents) else pRecentEvents
 
-        val deduped = if (ew.removeDuplicates) removePDuplicates(sc,updated) else updated
+        val deduped = if (ew.removeDuplicates) removePDuplicates(sc, updated) else updated
         deduped
       case None =>
-        pEvents
+        pRecentEvents
     }
-  getCleanedPEvents(rdd)
   }
 
   /** :: DeveloperApi ::
@@ -263,17 +263,17 @@ trait SelfCleaningDataSource {
   @DeveloperApi
   def cleanLEvents(): Iterable[Event] = {
     val lEvents = LEventStore.find(appName).toList.sortBy(_.eventTime).reverse
+    val lRecentEvents = getCleanedLEvents(lEvents)
 
-    val events = eventWindow match {
+    eventWindow match {
       case Some(ew) =>
         var updated =
-          if (ew.compressProperties) compressLProperties(lEvents) else lEvents
+          if (ew.compressProperties) compressLProperties(lRecentEvents) else lRecentEvents
           val deduped = if (ew.removeDuplicates) removeLDuplicates(updated) else updated
         deduped
       case None =>
-        lEvents
+        lRecentEvents
     }
-    getCleanedLEvents(events)
   }
 
 


### PR DESCRIPTION
Please direct me to contributor guidelines that I might be unaware of and I'll update. Otherwise continue with the PR:

This PR fixes ~~two issues~~ one issue with SelfCleaningDataSource when event compression is turned on:
1. For multiple events involving same entity id/type, earlier events will incorrectly overwrite the fields of later events due to the sort order of events being ASC instead of DESC.

    For example, say we run PIO import for the following JSON events:

event 1:
```
{
	"entityId": "product1",
	"entityType": "item",
	"event": "$set",
	"eventTime": "2016-10-13T12:26:51.000+0000",
	"properties": {
		"available": "2016-10-28T06:00:00+00:00",
		"expires": "2016-10-31T11:56:11+00:00"
	}
}
```

event2
```
{
	"entityId": "product1",
	"entityType": "item",
	"event": "$set",
	"eventTime": "2016-10-27T13:31:56.000+0000",
	"properties": {
		"available": "2016-11-15T06:00:00+00:00",
		"expires": "2016-11-22T23:59:59+00:00"
	}
}
```

event3
```
{
	"entityId": "product1",
	"entityType": "item",
	"event": "$set",
	"eventTime": "2016-11-02T12:31:12.000+0000",
	"properties": {
		"available": "2016-11-03T06:00:00+00:00",
		"expires": "2016-11-05T10:26:12+00:00"
	}
}
```

The resulting compressed record will be the following (which is incorrect):

```
[{
	"eventId": "...",
	"event": "$set",
	"entityType": "item",
	"entityId": "product1",
	"properties": {
		"available": "2016-10-28T06:00:00+00:00",
		"expires": "2016-10-31T11:56:11+00:00"
	},
	"eventTime": "2016-11-02T12:31:12.000Z",
	"creationTime": "2016-11-02T12:31:12.000Z"
}]
```

What happened is the later event is processed first (hence the event time of 2016-11-02T12:31:12.000Z) but the fields are updated with older subsequent events (hence the earlier available and expires date). This PR fixes that problem, but also reveals the second issue:


~~2. Older events are getting compressed prior to being filtered out of the duration. This PR filters out old events first, and then does the de-duplication and compression.~~

The final, correct compressed result will look like:
```
[{
	"eventId": "...",
	"event": "$set",
	"entityType": "item",
	"entityId": "product1",
	"properties": {
		"available": "2016-11-03T06:00:00+00:00",
		"expires": "2016-11-05T10:26:12+00:00"
	},
	"eventTime": "2016-11-02T12:31:12.000Z",
	"creationTime": "2016-11-02T12:31:12.000Z"
}]
```